### PR TITLE
Fixed bugs

### DIFF
--- a/Tendon_Limb_Design/Code/Tendon_Limb_Design.m~
+++ b/Tendon_Limb_Design/Code/Tendon_Limb_Design.m~
@@ -2,7 +2,7 @@ clear all
 % close all
 
 motorForce=49*.85; 	%__tendon tensions that the Faulhaber23.. motors can generate, 49 is in Stall Torque, we can't consider that value
-F01 = 43; F02 = 43; F03 = 43;  %Force values 
+F01 = 4; F02 = 43; F03 = 43;  %Force values 
 
 r1 = 2.3; r2 = 2.3;                          % cm
  
@@ -10,11 +10,11 @@ l1 = 8; l2 = 7.84;                           % cm
 
 F0 = diag([F01; F02; F03]);  %Diagnal matrix for Fmax           
 
-R_Front = [+r1 -r1 -r1 ;                   % Moment arm matrices
-           0  -r2 r2 ];
+%R_Front = [+r1 -r1 -r1 ;                   % Moment arm matrices
+%            0  -r2 r2 ];
         
-% R_Front = [-r1 -r1 +r1 ;                   % Moment arm matrices
-%             r2  -r2 0 ];
+R_Front = [-r1 -r1 +r1 ;                   % Moment arm matrices
+            r2  -r2 0 ];
 
         
 q=[1 30                       % Angle of the joints (for all the required postures)
@@ -27,16 +27,12 @@ for i=1:1
 
         % H_front =  R_Front * F0;                         %For torque space plots.
 
-        H_front = J_inv_Front'* (R_Front * F0)                % Fot force space plots.%
+        H_front = J_inv_Front.'* R_Front * F0                % Fot force space plots.%
         
         % %       V1          V2          V3          V4   (force vectors)
-        
-%           x_F = [ H_front(1,3) H_front(1,2) H_front(1,1) ];
-%           y_F = [H_front(2,3) H_front(2,2) H_front(2,1) ];
-%           
         x_F = [H_front(1,1) H_front(1,2) H_front(1,3) ];
         y_F = [H_front(2,1) H_front(2,2) H_front(2,3) ];
-%         
+        
 
         comb=[0 0 0 
             0 0 1
@@ -73,7 +69,7 @@ for i=1:1
         k = convhull(vertex,vertey);                            %Showing the convex polygon formed by the column space created by Minkoski sum                      
         plot(vertex(k),vertey(k),'r-',vertex,vertey,'b*')
 
-%         LimbFigure(q(i,1), q(i,2), l1, l2,-5,5,-5,5)
+        LimbFigure(q(i,1), q(i,2), l1, l2,-5,5,-5,5)
 
 end
 


### PR DESCRIPTION
The colums of the moment arm matrix can be interchanged. The order of the forces represented in F needs to bechanged accordingly.

The bug was in having 4 instead of 43 N in one of the motor forces.